### PR TITLE
feat: add oRPC documentation configuration

### DIFF
--- a/repos/orpc/meta.json
+++ b/repos/orpc/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/unnoq/orpc",
+  "branch": "main",
+  "docsPath": "apps/content",
+  "outputPath": "output/orpc",
+  "preset": "fumadocs"
+}


### PR DESCRIPTION
## Summary
- Added configuration for oRPC documentation repository
- Configured Fumadocs preset for proper component handling
- Set up documentation path to `apps/content` directory

## Test plan
- [ ] Run single repository build workflow for oRPC
- [ ] Verify documentation conversion completes successfully
- [ ] Check output files in `output/orpc` directory

Generated with [Claude Code](https://claude.ai/code)