### PR TITLE
feat: add Playwright documentation configuration

### DIFF
--- a/repos/playwright/meta.json
+++ b/repos/playwright/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/microsoft/playwright",
+  "branch": "main",
+  "docsPath": "docs",
+  "outputPath": "output/playwright",
+  "preset": "docusaurus"
+}


### PR DESCRIPTION
## Summary
- Added Playwright documentation configuration for MDX to Markdown conversion
- Repository: https://github.com/microsoft/playwright
- Docs path: docs
- Preset: docusaurus

## Test Results
- Successfully converted 44 files
- Failed/Partial: 128 files (MDX parsing errors preserved with warnings)
- Total output: 172 files

## Status
✅ Playwright documentation added to Tier 1 processing list