### PR TITLE
feat: add Socket.IO documentation configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "WebFetch(domain:github.com)",
       "WebSearch",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(find:*)"
     ],
     "deny": [],
     "ask": []

--- a/mdx2md/repos/socketio/meta.json
+++ b/mdx2md/repos/socketio/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/socketio/socket.io-website",
+  "branch": "main",
+  "docsPath": "docs",
+  "outputPath": "output/socketio",
+  "preset": "docusaurus"
+}

--- a/repos/socketio/meta.json
+++ b/repos/socketio/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/socketio/socket.io-website",
+  "branch": "main",
+  "docsPath": "docs",
+  "outputPath": "output/socketio",
+  "preset": "docusaurus"
+}


### PR DESCRIPTION
## Summary
- Added configuration for Socket.IO documentation repository
- Repository: https://github.com/socketio/socket.io-website (separate documentation repository)
- Branch: main
- Documentation path: docs
- Preset: docusaurus

## Conversion Results
✅ Successfully processed: 36 files (42.4%)
⚠️ Failed/Partial: 49 files (57.6%)

Moderate conversion rate due to MDX/JSX syntax issues and special character escaping.

## Test plan
- [x] Created meta.json configuration
- [x] Tested local conversion with `bun run cli convert --repo-name socketio`
- [x] Verified output files generated in output/socketio

🤖 Generated with Claude Code