### PR TITLE
feat: add Element Plus documentation support

### DIFF
--- a/repos/element-plus/meta.json
+++ b/repos/element-plus/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/element-plus/element-plus",
+  "branch": "master",
+  "docsPath": "docs",
+  "outputPath": "output/element-plus",
+  "preset": "vitepress"
+}


### PR DESCRIPTION
## Summary
- Add configuration for Element Plus documentation repository
- Repository: https://github.com/element-plus/element-plus
- Documentation path: `/docs`
- Uses VitePress preset for component mappings

## Conversion Results
- **Successfully processed:** 15 files
- **Failed/Partial:** 87 files
- **Success rate:** 14.7%

## Notes
Element Plus documentation uses extensive VitePress-specific directives and Vue components that are challenging to convert to standard Markdown. The low success rate is due to:
- Extensive use of `containerDirective` nodes
- Vue JSX elements in documentation
- VitePress-specific syntax and features

## Test plan
- [x] Repository clones successfully
- [x] Configuration file created
- [x] Conversion tested with `bun run cli convert --repo-name element-plus`
- [x] Output generated in `output/element-plus/`

🤖 Generated with [Claude Code](https://claude.ai/code)