### PR TITLE
feat: add VuePress documentation support

### DIFF
--- a/repos/vuepress/meta.json
+++ b/repos/vuepress/meta.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/vuejs/vuepress",
+  "branch": "main",
+  "docsPath": "docs",
+  "outputPath": "output/vuepress",
+  "preset": "vitepress"
+}


### PR DESCRIPTION
## Summary
- Add configuration for VuePress documentation repository
- Repository: https://github.com/vuejs/vuepress
- Documentation path: `/docs`
- Uses VitePress preset for component mappings

## Conversion Results
- **Successfully processed:** 87 files
- **Failed/Partial:** 25 files
- **Success rate:** 77.7%

## Test plan
- [x] Repository clones successfully
- [x] Configuration file created
- [x] Conversion tested with `bun run cli convert --repo-name vuepress`
- [x] Output generated in `output/vuepress/`

🤖 Generated with [Claude Code](https://claude.ai/code)